### PR TITLE
Submit this to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.history

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # cboMP3
-Tool convert bitrate in mp3 File.
+
+Tool convert mp3 Files to mp3 to any bitrate.
+
+## Install pip
+
+```bash
+pip install cboMP3
+```
+
+## Install if not installing with pip and just wanting to run core/cbo_mp3.py directly as a MAIN after cloning this repo
+
+```bash
+pip install ffmpy
+pip install mutagen
+```
+
+## Usage
+
+```python
+from cboMP3 import core.cbo_mp3 as CBOMp3
+cbo = CBOMp3(bitrate=320)
+mp3_files = cbo.get_mp3_files('J:\\myLargeMp3s\\') # Or Linux or mac paths should work too (untested)
+mp3_files = cbo.check_file_to_convert(mp3_files) # This filters out files that are already below the correct target bitrate
+cbo.convert_files(mp3_files) # Run The Job
+```
+
+Or you can use the command line tool if you download the git repo and install dependencies separately
+
+```bash
+  cd cboMP3/core
+  python cbo_mp3.py myfile.mp3 128
+```
+
+Or just the file path if you like 128 kb/s
+
+```bash
+  cd cboMP3/core
+  python cbo_mp3.py myfile.mp3
+```
+
+## Warning
+
+This tool will overwrite your files. Make sure you have backups prior to using

--- a/core/cbo_mp3.py
+++ b/core/cbo_mp3.py
@@ -29,7 +29,7 @@ class CBOMp3:
         """
         for mp3_file in mp3_files:
             audio = MP3(mp3_file)
-            if audio.info.bitrate > (self.bitrate * 1024):
+            if audio.info.bitrate > (self.bitrate * 1000):
                 print('File to convert: {}'.format(mp3_file))
             else:
                 mp3_files.remove(mp3_file)

--- a/core/cbo_mp3.py
+++ b/core/cbo_mp3.py
@@ -86,6 +86,6 @@ if __name__ == "__main__":
         mp3_files = [sys.argv[1]]
     else:
         # Hard code your recursive path to mp3 files
-        mp3_files = cbo.get_mp3_files('J:\\ah.fm\\2006\\Aug\\tmp\\')
+        mp3_files = cbo.get_mp3_files('J:\\myLargeMp3sIwantToSaveOnDiskSpace\\')
     mp3_files = cbo.check_file_to_convert(mp3_files)
     cbo.convert_files(mp3_files)

--- a/core/cbo_mp3.py
+++ b/core/cbo_mp3.py
@@ -2,7 +2,7 @@ import glob
 import ffmpy
 import os
 from mutagen.mp3 import MP3
-
+import shutil
 
 class CBOMp3:
 
@@ -23,7 +23,7 @@ class CBOMp3:
         """
         for mp3_file in mp3_files:
             audio = MP3(mp3_file)
-            if audio.info.bitrate > 256000:
+            if audio.info.bitrate > 128000:
                print('File to convert: {}'.format(mp3_file))
             else:
                mp3_files.remove(mp3_file)
@@ -39,12 +39,19 @@ class CBOMp3:
             dst_mp3 = self.create_dst_location(mp3_file)
             ff = ffmpy.FFmpeg(
                 inputs={mp3_file: None},
-                outputs={dst_mp3: '-acodec libmp3lame -b:a 256k'}
+                outputs={dst_mp3: '-acodec libmp3lame -b:a 128k'}
             )
             try:
                 ff.run()
+                print('File {} enocoded.'.format(dst_mp3))
+                shutil.copyfile(dst_mp3, mp3_file)
+                print('File {} copied.'.format(mp3_file))
+                os.remove(dst_mp3)
+                print('tmp file {} deleted.'.format(dst_mp3))
             except ffmpy.FFRuntimeError:
                 print('File {} already exists.'.format(dst_mp3))
+            except Exception as e:
+                print('Exception generic on ' + mp3_file, type(e), e)
 
     def create_dst_location(self, mp3_file):
         """

--- a/core/cbo_mp3.py
+++ b/core/cbo_mp3.py
@@ -1,10 +1,17 @@
 import glob
 import ffmpy
 import os
+import sys
 from mutagen.mp3 import MP3
 import shutil
+from sys import platform
+
 
 class CBOMp3:
+    def __init__(self, bitrate=128):
+        if bitrate == None:
+            bitrate = 128
+        self.bitrate = bitrate
 
     @staticmethod
     def get_mp3_files(dir_path=""):
@@ -15,18 +22,17 @@ class CBOMp3:
         """
         return glob.glob("{}*.mp3".format(dir_path))
 
-    @staticmethod
-    def check_file_to_convert(mp3_files):
+    def check_file_to_convert(self, mp3_files):
         """
         check bitrate of mp3 file and remove
         :return:
         """
         for mp3_file in mp3_files:
             audio = MP3(mp3_file)
-            if audio.info.bitrate > 128000:
-               print('File to convert: {}'.format(mp3_file))
+            if audio.info.bitrate > (self.bitrate * 1024):
+                print('File to convert: {}'.format(mp3_file))
             else:
-               mp3_files.remove(mp3_file)
+                mp3_files.remove(mp3_file)
         return mp3_files
 
     def convert_files(self, mp3_files):
@@ -36,10 +42,11 @@ class CBOMp3:
         :return:
         """
         for mp3_file in mp3_files:
-            dst_mp3 = self.create_dst_location(mp3_file)
+            dst_mp3 = self.generate_tmp_file_location(mp3_file)
             ff = ffmpy.FFmpeg(
                 inputs={mp3_file: None},
-                outputs={dst_mp3: '-acodec libmp3lame -b:a 128k'}
+                outputs={dst_mp3: '-acodec libmp3lame -b:a ' +
+                         str(self.bitrate) + 'k'}
             )
             try:
                 ff.run()
@@ -53,33 +60,32 @@ class CBOMp3:
             except Exception as e:
                 print('Exception generic on ' + mp3_file, type(e), e)
 
-    def create_dst_location(self, mp3_file):
+    def generate_tmp_file_location(self, mp3_file):
         """
 
         :param mp3_file:
         :return:
         """
-        mp3_file = mp3_file.split("\\")
-        song = mp3_file[len(mp3_file) - 1]
-        mp3_file[len(mp3_file) - 1] = "tmp"
-        # join
-        dst_file = '\\'.join([str(x) for x in mp3_file])
-        self.create_tmp_dir(dst_file)
-        return dst_file + "\\{}".format(song)
-
-    @staticmethod
-    def create_tmp_dir(dir_name):
-        """
-
-        :param dir_name:
-        :return:
-        """
-        if not os.path.exists(dir_name):
-            os.makedirs(dir_name)
+        folder = "/"
+        if platform == "win32":
+            folder = "\\"
+        folders = mp3_file.split(folder)
+        song = folders[len(folders) - 1]
+        folders.pop()
+        dst_file = folder.join([str(x) for x in folders])
+        return dst_file + folder + "{}".format("wip-" + song)
 
 
 if __name__ == "__main__":
     cbo = CBOMp3()
-    mp3_files = cbo.get_mp3_files('F:\\Robocik\\')
+    if len(sys.argv) >= 2:
+        bitrate = None
+        if len(sys.argv) == 3:
+            bitrate = sys.argv[2]
+        cbo = CBOMp3(bitrate)
+        mp3_files = [sys.argv[1]]
+    else:
+        # Hard code your recursive path to mp3 files
+        mp3_files = cbo.get_mp3_files('J:\\ah.fm\\2006\\Aug\\tmp\\')
     mp3_files = cbo.check_file_to_convert(mp3_files)
     cbo.convert_files(mp3_files)

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,21 @@
 import os
 from setuptools import setup
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 setup(
-    name = "cboMP3",
-    version = "1.0.0d",
-    author = "Madaoo",
-    author_email = "kielkowskimarcin@prokonto.pl",
-    description = ("Change bitrate in mp3 file"),
-    license = "MIT",
-    keywords = "mp3 bitratw converter",
-    packages = ['mutagen','ffmpy'],
+    name="cboMP3",
+    version="1.0.0d",
+    author="Madaoo",
+    author_email="kielkowskimarcin@prokonto.pl",
+    description=("Change bitrate in mp3 file"),
+    license="MIT",
+    keywords="mp3 bitratw converter",
+    packages=['mutagen', 'ffmpy'],
+    url='https://github.com/MadaooQuake/cboMP3',
     classifiers=[
         "Development:w"
         "Status :: 1.0.0dev1",


### PR DESCRIPTION
- Added some more docs
- Removed hard coded bitrate (defaulted to 128 kb/s because if you have large files typically 128 is best and most efficient with decent sound quality)
- Added ability to call python file with a single file as arg1 and bitrate as arg2 (because I intend to write a golang file to have 20 workers shelling out to this python script and processing 4 terrabytes or more of music at 320kb/s) so that this thing doesnt take years to process 4TB and that if there is some kind of memory leak in a long running python script processing thousands of files.  
- Support mac/linux paths (need to test a sample on a box, but it should work so long as ffmpeg is compiled to those arch's)
- Dont create lingering tmp dirs after processing.  Basically use "tmp-"{filename.mp3} as an inline working file.  Then copy to original.  Then delete tmp file that ffmpeg output.  Perhaps if you dont like this approach we could support your old way as a flag, but this is cleanest for someone wanting to re-encode entire libraries to 128kb or 192 or whatever. Your tmp dir is safest, however is a nightmare to copy/move if you have lots of directories to delete the tmp dir after verifying ffmpeg worked fine (which it should)
- Catch generic exceptions on ffmpeg

Consider publishing this to pypi soon and I can verify my little examples work